### PR TITLE
Fix errors in test failure messages.

### DIFF
--- a/ntlm/ntlmv1_test.go
+++ b/ntlm/ntlmv1_test.go
@@ -62,7 +62,7 @@ func TestNtlmV1ExtendedSessionSecurity(t *testing.T) {
 	context.SetServerChallenge(c.ServerChallenge)
 	err = context.ProcessAuthenticateMessage(msg)
 	if err == nil {
-		t.Errorf("This message should have failed to authenticate, but it passed", err)
+		t.Error("This message should have failed to authenticate, but it passed")
 	}
 }
 

--- a/ntlm/ntlmv2_test.go
+++ b/ntlm/ntlmv2_test.go
@@ -172,7 +172,7 @@ func TestNTLMv2WithDomain(t *testing.T) {
 
 	err := server.ProcessAuthenticateMessage(a)
 	if err != nil {
-		t.Error("Could not process authenticate message: %s\n", err)
+		t.Errorf("Could not process authenticate message: %s\n", err)
 	}
 }
 


### PR DESCRIPTION
These break compile with Go 1.10.